### PR TITLE
Config source

### DIFF
--- a/scalecube-configuration-api/src/main/java/io/scalecube/configuration/api/ConfigurationService.java
+++ b/scalecube-configuration-api/src/main/java/io/scalecube/configuration/api/ConfigurationService.java
@@ -3,6 +3,7 @@ package io.scalecube.configuration.api;
 import io.scalecube.services.annotations.Service;
 import io.scalecube.services.annotations.ServiceMethod;
 import java.util.List;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -18,6 +19,7 @@ public interface ConfigurationService {
 
   String CONFIG_CREATE_REPO = "configuration/createRepository";
   String CONFIG_FETCH = "configuration/fetch";
+  String CONFIG_FETCH_ALL = "configuration/fetchAll";
   String CONFIG_ENTRIES = "configuration/entries";
   String CONFIG_SAVE = "configuration/save";
   String CONFIG_DELETE = "configuration/delete";
@@ -48,7 +50,16 @@ public interface ConfigurationService {
    */
   @ServiceMethod
   Mono<List<FetchResponse>> entries(EntriesRequest request);
-
+  
+  /**
+   * Entries request requires read level permissions to list all entries objects from the store.
+   *
+   * @param request includes the name of the repository to list.
+   * @return list of FetchResponses per each entry in the repository.
+   */
+  @ServiceMethod
+  Flux<FetchResponse> fetchAll(EntriesRequest request);
+  
   /**
    * Save request requires write level permissions to save (create or update) entry to the store.
    *

--- a/scalecube-configuration/src/test/java/io/scalecube/configuration/FetchEntriesTest.java
+++ b/scalecube-configuration/src/test/java/io/scalecube/configuration/FetchEntriesTest.java
@@ -18,6 +18,7 @@ import io.scalecube.configuration.fixtures.InMemoryConfigurationServiceFixture;
 import io.scalecube.configuration.repository.exception.RepositoryNotFoundException;
 import io.scalecube.test.fixtures.Fixtures;
 import io.scalecube.test.fixtures.WithFixture;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -43,8 +44,8 @@ final class FetchEntriesTest extends BaseTest {
     String memberToken = getApiKey(organizationService, orgId, Role.Member).key();
 
     String repoName = "test-repo";
-    String entryKey1 = "KEY-FOR-PRECIOUS-METAL-123";
-    String entryKey2 = "KEY-FOR-CURRENCY-999";
+    String entryKey1 = "KEY-FOR-CURRENCY-999";
+    String entryKey2 = "KEY-FOR-PRECIOUS-METAL-123";
 
     configurationService
         .createRepository(new CreateRepositoryRequest(ownerToken, repoName))
@@ -73,7 +74,46 @@ final class FetchEntriesTest extends BaseTest {
                         .put("DecimalPrecision", 2)
                         .put("Rounding", "down"))))
         .block(TIMEOUT);
+    test26WithEntriesMethod(
+        configurationService,
+        organizationService,
+        repoName,
+        ownerToken,
+        adminToken,
+        memberToken,
+        entryKey1,
+        entryKey2);
+    test26WithFetchAllMethod(
+        configurationService,
+        organizationService,
+        repoName,
+        ownerToken,
+        adminToken,
+        memberToken,
+        entryKey1,
+        entryKey2);
+    ;
+  }
 
+  /**
+   * @param configurationService
+   * @param organizationService
+   * @param ownerToken
+   * @param adminToken
+   * @param memberToken
+   * @param entryKey1
+   * @throws AssertionError
+   */
+  private static void test26WithEntriesMethod(
+      ConfigurationService configurationService,
+      OrganizationService organizationService,
+      String repoName,
+      Object ownerToken,
+      Object adminToken,
+      Object memberToken,
+      String entryKey1,
+      String entryKey2)
+      throws AssertionError {
     StepVerifier.create(configurationService.entries(new EntriesRequest(ownerToken, repoName)))
         .assertNext(
             entries -> {
@@ -123,6 +163,54 @@ final class FetchEntriesTest extends BaseTest {
         .verify();
   }
 
+  /**
+   * @param configurationService
+   * @param organizationService
+   * @param ownerToken
+   * @param adminToken
+   * @param memberToken
+   * @param entryKey1
+   * @throws AssertionError
+   */
+  private static void test26WithFetchAllMethod(
+      ConfigurationService configurationService,
+      OrganizationService organizationService,
+      String repoName,
+      Object ownerToken,
+      Object adminToken,
+      Object memberToken,
+      String entryKey1,
+      String entryKey2)
+      throws AssertionError {
+
+    StepVerifier.create(
+            configurationService
+                .fetchAll(new EntriesRequest(ownerToken, repoName))
+                .sort(Comparator.comparing(FetchResponse::key)))
+        .assertNext(response -> assertEquals(entryKey1, response.key(), "entry 1 exists"))
+        .assertNext(response -> assertEquals(entryKey2, response.key(), "entry 2 exists"))
+        .expectComplete()
+        .verify();
+
+    StepVerifier.create(
+            configurationService
+                .fetchAll(new EntriesRequest(adminToken, repoName))
+                .sort(Comparator.comparing(FetchResponse::key)))
+        .assertNext(response -> assertEquals(entryKey1, response.key(), "entry 1 exists"))
+        .assertNext(response -> assertEquals(entryKey2, response.key(), "entry 2 exists"))
+        .expectComplete()
+        .verify();
+
+    StepVerifier.create(
+            configurationService
+                .fetchAll(new EntriesRequest(memberToken, repoName))
+                .sort(Comparator.comparing(FetchResponse::key)))
+        .assertNext(response -> assertEquals(entryKey1, response.key(), "entry 1 exists"))
+        .assertNext(response -> assertEquals(entryKey2, response.key(), "entry 2 exists"))
+        .expectComplete()
+        .verify();
+  }
+
   @TestTemplate
   @DisplayName(
       "#27 Fail to get any entry from the non-existent Repository applying some of the accessible API keys: \"Owner\", \"Admin\", \"Member\"")
@@ -145,6 +233,26 @@ final class FetchEntriesTest extends BaseTest {
 
   @TestTemplate
   @DisplayName(
+      "#27 Fail to get any entry from the non-existent Repository applying some of the accessible API keys: \"Owner\", \"Admin\", \"Member\"")
+  void fetchAllFromNonExistentRepository(
+      ConfigurationService configurationService, OrganizationService organizationService) {
+    String orgId = getOrganization(organizationService, ORGANIZATION_1).id();
+    String token = getApiKey(organizationService, orgId, Role.Admin).key();
+
+    String repoName = "NON_EXISTENT_REPO";
+
+    StepVerifier.create(configurationService.fetchAll(new EntriesRequest(token, repoName)))
+        .expectErrorSatisfies(
+            e -> {
+              assertEquals(RepositoryNotFoundException.class, e.getClass());
+              assertEquals(
+                  String.format("Repository '%s-%s' not found", orgId, repoName), e.getMessage());
+            })
+        .verify();
+  }
+  
+  @TestTemplate
+  @DisplayName(
       "#28 Fail to get any entry from the Repository upon the \"token\" is invalid (expired)")
   void fetchEntriesUsingExpiredToken(
       ConfigurationService configurationService, OrganizationService organizationService) {
@@ -160,6 +268,23 @@ final class FetchEntriesTest extends BaseTest {
         .verify();
   }
 
+  @TestTemplate
+  @DisplayName(
+      "#28 Fail to get any entry from the Repository upon the \"token\" is invalid (expired)")
+  void fetchAllUsingExpiredToken(
+      ConfigurationService configurationService, OrganizationService organizationService) {
+    String orgId = getOrganization(organizationService, ORGANIZATION_1).id();
+    String token = getExpiredApiKey(organizationService, orgId, Role.Owner).key();
+
+    StepVerifier.create(configurationService.fetchAll(new EntriesRequest(token, "test-repo")))
+        .expectErrorSatisfies(
+            e -> {
+              assertEquals(InvalidAuthenticationToken.class, e.getClass());
+              assertEquals("Token verification failed", e.getMessage());
+            })
+        .verify();
+  }
+  
   @TestTemplate
   @DisplayName(
       "#29 Fail to get any entry from the Repository upon the Owner deleted the Organization with related \"Member\" API key")
@@ -206,6 +331,50 @@ final class FetchEntriesTest extends BaseTest {
 
   @TestTemplate
   @DisplayName(
+      "#29 Fail to get any entry from the Repository upon the Owner deleted the Organization with related \"Member\" API key")
+  void fetchAllForDeletedOrganization(
+      ConfigurationService configurationService, OrganizationService organizationService)
+      throws InterruptedException {
+    String orgId = getOrganization(organizationService, ORGANIZATION_1).id();
+    String ownerToken = getApiKey(organizationService, orgId, Role.Owner).key();
+    String memberToken = getApiKey(organizationService, orgId, Role.Member).key();
+
+    String repoName = "test-repo";
+    String entryKey = "KEY-FOR-PRECIOUS-METAL-123";
+
+    configurationService
+        .createRepository(new CreateRepositoryRequest(ownerToken, repoName))
+        .then(
+            configurationService.save(
+                new SaveRequest(
+                    ownerToken,
+                    repoName,
+                    entryKey,
+                    OBJECT_MAPPER
+                        .createObjectNode()
+                        .put("instrumentId", "XAG")
+                        .put("name", "Silver")
+                        .put("DecimalPrecision", 4)
+                        .put("Rounding", "down"))))
+        .block(TIMEOUT);
+
+    organizationService
+        .deleteOrganization(new DeleteOrganizationRequest(AUTH0_TOKEN, "ORG-TEST"))
+        .block(TIMEOUT);
+
+    TimeUnit.SECONDS.sleep(3);
+
+    StepVerifier.create(configurationService.fetchAll(new EntriesRequest(memberToken, repoName)))
+        .expectErrorSatisfies(
+            e -> {
+              assertEquals(InvalidAuthenticationToken.class, e.getClass());
+              assertEquals("Token verification failed", e.getMessage());
+            })
+        .verify();
+  }
+  
+  @TestTemplate
+  @DisplayName(
       "#30 Fail to get any entry from the Repository upon the Owner applied some of the API keys from another Organization")
   void fetchEntriesUsingTokenOfAnotherOrganization(
       ConfigurationService configurationService, OrganizationService organizationService) {
@@ -244,6 +413,46 @@ final class FetchEntriesTest extends BaseTest {
         .verify();
   }
 
+  @TestTemplate
+  @DisplayName(
+      "#30 Fail to get any entry from the Repository upon the Owner applied some of the API keys from another Organization")
+  void fetchAllUsingTokenOfAnotherOrganization(
+      ConfigurationService configurationService, OrganizationService organizationService) {
+    String orgId1 = getOrganization(organizationService, ORGANIZATION_1).id();
+    String token1 = getApiKey(organizationService, orgId1, Role.Owner).key();
+
+    String orgId2 = getOrganization(organizationService, ORGANIZATION_2).id();
+    String token2 = getApiKey(organizationService, orgId2, Role.Admin).key();
+
+    String repoName = "test-repo";
+    String entryKey = "KEY-FOR-PRECIOUS-METAL-123";
+
+    configurationService
+        .createRepository(new CreateRepositoryRequest(token1, repoName))
+        .then(
+            configurationService.save(
+                new SaveRequest(
+                    token1,
+                    repoName,
+                    entryKey,
+                    OBJECT_MAPPER
+                        .createObjectNode()
+                        .put("instrumentId", "XAG")
+                        .put("name", "Silver")
+                        .put("DecimalPrecision", 4)
+                        .put("Rounding", "down"))))
+        .block(TIMEOUT);
+
+    StepVerifier.create(configurationService.fetchAll(new EntriesRequest(token2, repoName)))
+        .expectErrorSatisfies(
+            e -> {
+              assertEquals(RepositoryNotFoundException.class, e.getClass());
+              assertEquals(
+                  String.format("Repository '%s-%s' not found", orgId2, repoName), e.getMessage());
+            })
+        .verify();
+  }
+  
   @Disabled("Feature is not implemented")
   @TestTemplate
   @DisplayName(
@@ -279,6 +488,49 @@ final class FetchEntriesTest extends BaseTest {
         .block(TIMEOUT);
 
     StepVerifier.create(configurationService.entries(new EntriesRequest(memberToken, repoName)))
+        .expectErrorSatisfies(
+            e -> {
+              assertEquals(InvalidAuthenticationToken.class, e.getClass());
+              assertEquals("Token verification failed", e.getMessage());
+            })
+        .verify();
+  }
+  
+  @Disabled("Feature is not implemented")
+  @TestTemplate
+  @DisplayName(
+      "#31 Fail to get any entry from the Repository upon the Member \"token\" (API key) was deleted from the Organization")
+  void fetchAllUsingDeletedToken(
+      ConfigurationService configurationService, OrganizationService organizationService) {
+    String orgId = getOrganization(organizationService, ORGANIZATION_1).id();
+    ApiKey ownerToken = getApiKey(organizationService, orgId, Role.Owner);
+    ApiKey memberToken = getApiKey(organizationService, orgId, Role.Member);
+
+    String repoName = "test-repo";
+    String entryKey = "KEY-FOR-PRECIOUS-METAL-123";
+
+    configurationService
+        .createRepository(new CreateRepositoryRequest(ownerToken, repoName))
+        .then(
+            configurationService.save(
+                new SaveRequest(
+                    ownerToken,
+                    repoName,
+                    entryKey,
+                    OBJECT_MAPPER
+                        .createObjectNode()
+                        .put("instrumentId", "XAG")
+                        .put("name", "Silver")
+                        .put("DecimalPrecision", 4)
+                        .put("Rounding", "down"))))
+        .block(TIMEOUT);
+
+    organizationService
+        .deleteOrganizationApiKey(
+            new DeleteOrganizationApiKeyRequest(AUTH0_TOKEN, orgId, memberToken.name()))
+        .block(TIMEOUT);
+
+    StepVerifier.create(configurationService.fetchAll(new EntriesRequest(memberToken, repoName)))
         .expectErrorSatisfies(
             e -> {
               assertEquals(InvalidAuthenticationToken.class, e.getClass());


### PR DESCRIPTION
Reasoning: the interface of entries is `Mono<List<FetchResponse>>` and scalecube does not support 2 layers of generics.